### PR TITLE
Feature/22

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,7 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 
     implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
+    implementation 'org.apache.httpcomponents.client5:httpclient5:5.2.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/flab/payment_system/adapter/PaymentAdapter.java
+++ b/src/main/java/flab/payment_system/adapter/PaymentAdapter.java
@@ -17,8 +17,8 @@ public class PaymentAdapter {
 
 	private final PaymentService paymentService;
 
-	public PaymentApprovalDto approvePayment(String pgToken, long orderId, long userId,
-		long paymentId) {
+	public PaymentApprovalDto approvePayment(String pgToken, Long orderId, Long userId,
+		Long paymentId) {
 		return paymentService.approvePayment(pgToken, orderId, userId, paymentId);
 	}
 
@@ -27,7 +27,7 @@ public class PaymentAdapter {
 	}
 
 	public PaymentReadyDto createPayment(OrderProductDto orderProductDto, String requestUrl,
-		long userId, long orderId, PaymentPgCompany pgCompany) {
+		Long userId, Long orderId, PaymentPgCompany pgCompany) {
 		return paymentService.createPayment(orderProductDto, requestUrl, userId, orderId,
 			pgCompany);
 	}

--- a/src/main/java/flab/payment_system/adapter/ProductAdapter.java
+++ b/src/main/java/flab/payment_system/adapter/ProductAdapter.java
@@ -10,7 +10,7 @@ public class ProductAdapter {
 
 	private final ProductService productService;
 
-	public void checkRemainStock(long productId) {
+	public void checkRemainStock(Long productId) {
 		productService.checkRemainStock(productId);
 	}
 
@@ -18,7 +18,7 @@ public class ProductAdapter {
 		productService.decreaseStock(productId, quantity);
 	}
 
-	public void increaseStock(long productId, Integer quantity) {
+	public void increaseStock(Long productId, Integer quantity) {
 		productService.increaseStock(productId, quantity);
 	}
 }

--- a/src/main/java/flab/payment_system/config/AppConfig.java
+++ b/src/main/java/flab/payment_system/config/AppConfig.java
@@ -81,7 +81,7 @@ public class AppConfig {
 		return HttpClientBuilder.create()
 			.setConnectionManager(PoolingHttpClientConnectionManagerBuilder.create()
 				.setMaxConnPerRoute(30)
-				.setMaxConnTotal(100)
+				.setMaxConnTotal(60)
 				.build())
 			.build();
 	}

--- a/src/main/java/flab/payment_system/domain/order/controller/OrderController.java
+++ b/src/main/java/flab/payment_system/domain/order/controller/OrderController.java
@@ -45,11 +45,11 @@ public class OrderController {
 		String requestUrl = request.getRequestURL().toString()
 			.replace(request.getRequestURI(), "");
 
-		long userId = userAdapter.getUserId(session);
+		Long userId = userAdapter.getUserId(session);
 
 		productAdapter.checkRemainStock(orderProductDto.productId());
 
-		long orderId = orderService.orderProduct(orderProductDto, userId);
+		Long orderId = orderService.orderProduct(orderProductDto, userId);
 
 		paymentAdapter.setStrategy(pgCompany);
 		PaymentReadyDto paymentReadyDto = paymentAdapter.createPayment(orderProductDto, requestUrl,

--- a/src/main/java/flab/payment_system/domain/order/dto/OrderCancelDto.java
+++ b/src/main/java/flab/payment_system/domain/order/dto/OrderCancelDto.java
@@ -9,9 +9,9 @@ public record OrderCancelDto(
 	@Min(value = 1, message = "invalid_cancel_tax_free_amount")
 	Integer cancelTaxFreeAmount,
 	@Min(value = 1, message = "invalid_order_id")
-	long orderId,
+	Long orderId,
 	@Min(value = 1, message = "invalid_product_id")
-	long productId,
+	Long productId,
 	@Min(value = 1, message = "invalid_quantity")
 	Integer quantity
 ) {

--- a/src/main/java/flab/payment_system/domain/order/dto/OrderProductDto.java
+++ b/src/main/java/flab/payment_system/domain/order/dto/OrderProductDto.java
@@ -6,9 +6,9 @@ import java.util.Optional;
 public record OrderProductDto(
 	String productName,
 	@Min(value = 1, message = "invalid_product_id")
-	long productId,
+	Long productId,
 	@Min(value = 1, message = "invalid_quantity")
-	int quantity,
+	Integer quantity,
 	@Min(value = 1, message = "invalid_total_amount")
 	Integer totalAmount,
 	@Min(value = 1, message = "invalid_tax_free_amount")

--- a/src/main/java/flab/payment_system/domain/order/service/OrderService.java
+++ b/src/main/java/flab/payment_system/domain/order/service/OrderService.java
@@ -15,7 +15,7 @@ public class OrderService {
 
 	private final OrderRepository orderRepository;
 
-	public long orderProduct(OrderProductDto orderProductDto, long userId) {
+	public Long orderProduct(OrderProductDto orderProductDto, Long userId) {
 		AtomicReference<Integer> installMonth = new AtomicReference<>(0);
 		Optional<Integer> optionalInstallMonth = orderProductDto.getInstallMonth();
 		optionalInstallMonth.ifPresent(installMonth::set);

--- a/src/main/java/flab/payment_system/domain/payment/controller/PaymentController.java
+++ b/src/main/java/flab/payment_system/domain/payment/controller/PaymentController.java
@@ -33,7 +33,7 @@ public class PaymentController {
 		@RequestParam("quantity") Integer quantity,
 		HttpSession session) {
 		paymentService.setStrategy(pgCompany);
-		long userId = userAdapter.getUserId(session);
+		Long userId = userAdapter.getUserId(session);
 		PaymentApprovalDto paymentApprovalDto = redissonLockAdapter.approvePayment(pgToken, orderId,
 			userId, paymentId, productId, quantity);
 

--- a/src/main/java/flab/payment_system/domain/payment/domain/kakao/Amount.java
+++ b/src/main/java/flab/payment_system/domain/payment/domain/kakao/Amount.java
@@ -13,12 +13,12 @@ import lombok.Setter;
 @Embeddable
 public class Amount {
 
-	private int total;
+	private Integer total;
 	@Column(name = "tax_free")
-	private int taxFree;
-	private int tax;
-	private int point;
-	private int discount;
+	private Integer taxFree;
+	private Integer tax;
+	private Integer point;
+	private Integer discount;
 	@Column(name = "green_deposit")
-	private int greenDeposit;
+	private Integer greenDeposit;
 }

--- a/src/main/java/flab/payment_system/domain/payment/repository/PaymentCustomRepository.java
+++ b/src/main/java/flab/payment_system/domain/payment/repository/PaymentCustomRepository.java
@@ -2,8 +2,8 @@ package flab.payment_system.domain.payment.repository;
 
 public interface PaymentCustomRepository {
 
-	long updatePaymentStateByPaymentId(long paymentId, Integer state);
+	long updatePaymentStateByPaymentId(Long paymentId, Integer state);
 
-	long updatePaymentStateByOrderId(long paymentId, Integer state);
+	long updatePaymentStateByOrderId(Long paymentId, Integer state);
 
 }

--- a/src/main/java/flab/payment_system/domain/payment/repository/PaymentCustomRepositoryImpl.java
+++ b/src/main/java/flab/payment_system/domain/payment/repository/PaymentCustomRepositoryImpl.java
@@ -17,7 +17,7 @@ public class PaymentCustomRepositoryImpl implements PaymentCustomRepository {
 	@Override
 	@Transactional
 	@Modifying(clearAutomatically = true)
-	public long updatePaymentStateByPaymentId(long paymentId, Integer state) {
+	public long updatePaymentStateByPaymentId(Long paymentId, Integer state) {
 		return jpaQueryFactory.update(payment)
 			.set(payment.state, state)
 			.where(payment.paymentId.eq(paymentId)).execute();
@@ -26,7 +26,7 @@ public class PaymentCustomRepositoryImpl implements PaymentCustomRepository {
 	@Override
 	@Transactional
 	@Modifying(clearAutomatically = true)
-	public long updatePaymentStateByOrderId(long orderId, Integer state) {
+	public long updatePaymentStateByOrderId(Long orderId, Integer state) {
 		return jpaQueryFactory.update(payment)
 			.set(payment.state, state)
 			.where(payment.orderId.eq(orderId)).execute();

--- a/src/main/java/flab/payment_system/domain/payment/request/kakao/PaymentKakaoRequestBodyFactory.java
+++ b/src/main/java/flab/payment_system/domain/payment/request/kakao/PaymentKakaoRequestBodyFactory.java
@@ -41,7 +41,7 @@ public class PaymentKakaoRequestBodyFactory {
 
 	public HttpEntity<MultiValueMap<String, String>> getBodyForCreatePayment(
 		OrderProductDto orderProductDto,
-		long userId, String requestUrl, long orderId, long paymentId, long productId) {
+		Long userId, String requestUrl, Long orderId, Long paymentId, Long productId) {
 		HttpHeaders headers = getHeaders();
 
 		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
@@ -71,7 +71,7 @@ public class PaymentKakaoRequestBodyFactory {
 	}
 
 	public HttpEntity<MultiValueMap<String, String>> getBodyForApprovePayment(String pgToken,
-		long orderId, long userId, long paymentId) {
+		Long orderId, Long userId, Long paymentId) {
 		HttpHeaders headers = getHeaders();
 
 		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();

--- a/src/main/java/flab/payment_system/domain/payment/request/toss/PaymentTossRequestBodyFactory.java
+++ b/src/main/java/flab/payment_system/domain/payment/request/toss/PaymentTossRequestBodyFactory.java
@@ -31,8 +31,8 @@ public class PaymentTossRequestBodyFactory {
 
 
 	public HttpEntity<Map<String, String>> getBodyForCreatePayment(
-		OrderProductDto orderProductDto, long userId, String requestUrl, long orderId,
-		long paymentId, long productId) {
+		OrderProductDto orderProductDto, Long userId, String requestUrl, Long orderId,
+		Long paymentId, Long productId) {
 		HttpHeaders headers = getHeaders();
 		Map<String, String> params = new HashMap<>();
 
@@ -57,7 +57,7 @@ public class PaymentTossRequestBodyFactory {
 	}
 
 	public HttpEntity<Map<String, String>> getBodyForApprovePayment(
-		long orderId, long userId, long paymentId) {
+		Long orderId, Long userId, Long paymentId) {
 		HttpHeaders headers = getHeaders();
 
 		Map<String, String> params = new HashMap<>();

--- a/src/main/java/flab/payment_system/domain/payment/request/toss/PaymentTossRequestBodyFactory.java
+++ b/src/main/java/flab/payment_system/domain/payment/request/toss/PaymentTossRequestBodyFactory.java
@@ -36,7 +36,6 @@ public class PaymentTossRequestBodyFactory {
 		HttpHeaders headers = getHeaders();
 		Map<String, String> params = new HashMap<>();
 
-		params.put("apiKey", secretKey);
 		params.put("method", "간편결제");
 		params.put("taxFreeAmount", String.valueOf(orderProductDto.taxFreeAmount()));
 		params.put("orderId", "orderId_" + orderId + "_" + userId);

--- a/src/main/java/flab/payment_system/domain/payment/service/PaymentService.java
+++ b/src/main/java/flab/payment_system/domain/payment/service/PaymentService.java
@@ -39,7 +39,7 @@ public class PaymentService {
 
 	@Transactional
 	public PaymentReadyDto createPayment(OrderProductDto orderProductDto,
-		String requestUrl, long userId, long orderId, PaymentPgCompany paymentPgCompany) {
+		String requestUrl, Long userId, Long orderId, PaymentPgCompany paymentPgCompany) {
 
 		Payment payment = paymentRepository.save(
 			Payment.builder().orderId(orderId).state(PaymentStateConstant.ONGOING.getValue())
@@ -57,8 +57,8 @@ public class PaymentService {
 	}
 
 	@Transactional
-	public PaymentApprovalDto approvePayment(String pgToken, long orderId, long userId,
-		long paymentId) {
+	public PaymentApprovalDto approvePayment(String pgToken, Long orderId, Long userId,
+		Long paymentId) {
 
 		PaymentApprovalDto paymentApprovalDto = paymentStrategy.approvePayment(pgToken, orderId,
 			userId, paymentId);

--- a/src/main/java/flab/payment_system/domain/payment/service/PaymentStrategy.java
+++ b/src/main/java/flab/payment_system/domain/payment/service/PaymentStrategy.java
@@ -9,10 +9,10 @@ import flab.payment_system.domain.payment.response.PaymentReadyDto;
 
 public interface PaymentStrategy {
 
-	PaymentReadyDto createPayment(OrderProductDto orderProductDto, long userId, String requestUrl,
-		long orderId, long paymentId, long productId);
+	PaymentReadyDto createPayment(OrderProductDto orderProductDto, Long userId, String requestUrl,
+		Long orderId, Long paymentId, Long productId);
 
-	PaymentApprovalDto approvePayment(String pgToken, long orderId, long userId, long paymentId);
+	PaymentApprovalDto approvePayment(String pgToken, Long orderId, Long userId, Long paymentId);
 
 	PaymentCancelDto cancelPayment(OrderCancelDto orderCancelDto);
 

--- a/src/main/java/flab/payment_system/domain/payment/service/kakao/PaymentStrategyKaKaoService.java
+++ b/src/main/java/flab/payment_system/domain/payment/service/kakao/PaymentStrategyKaKaoService.java
@@ -38,8 +38,8 @@ public class PaymentStrategyKaKaoService implements PaymentStrategy {
 	}
 
 	@Override
-	public PaymentReadyDto createPayment(OrderProductDto orderProductDto, long userId,
-		String requestUrl, long orderId, long paymentId, long productId) {
+	public PaymentReadyDto createPayment(OrderProductDto orderProductDto,Long userId,
+		String requestUrl, Long orderId, Long paymentId, Long productId) {
 
 		HttpEntity<MultiValueMap<String, String>> body = paymentKakaoRequestBodyFactory.getBodyForCreatePayment(
 			orderProductDto, userId, requestUrl, orderId, paymentId, productId);
@@ -48,8 +48,8 @@ public class PaymentStrategyKaKaoService implements PaymentStrategy {
 	}
 
 	@Override
-	public PaymentApprovalDto approvePayment(String pgToken, long orderId, long userId,
-		long paymentId) {
+	public PaymentApprovalDto approvePayment(String pgToken, Long orderId, Long userId,
+		Long paymentId) {
 		HttpEntity<MultiValueMap<String, String>> body = paymentKakaoRequestBodyFactory.getBodyForApprovePayment(
 			pgToken, orderId,
 			userId, paymentId);

--- a/src/main/java/flab/payment_system/domain/payment/service/toss/PaymentStrategyTossService.java
+++ b/src/main/java/flab/payment_system/domain/payment/service/toss/PaymentStrategyTossService.java
@@ -43,16 +43,16 @@ public class PaymentStrategyTossService implements PaymentStrategy {
 
 
 	@Override
-	public PaymentReadyDto createPayment(OrderProductDto orderProductDto, long userId,
-		String requestUrl, long orderId, long paymentId, long productId) {
+	public PaymentReadyDto createPayment(OrderProductDto orderProductDto, Long userId,
+		String requestUrl, Long orderId, Long paymentId, Long productId) {
 		HttpEntity<Map<String, String>> body = paymentTossRequestBodyFactory.getBodyForCreatePayment(
 			orderProductDto, userId, requestUrl, orderId, paymentId, productId);
 		return paymentTossClient.createPayment(tossHost, body);
 	}
 
 	@Override
-	public PaymentApprovalDto approvePayment(String pgToken, long orderId, long userId,
-		long paymentId) {
+	public PaymentApprovalDto approvePayment(String pgToken, Long orderId, Long userId,
+		Long paymentId) {
 		HttpEntity<Map<String, String>> body = paymentTossRequestBodyFactory.getBodyForApprovePayment(
 			orderId, userId, paymentId);
 		PaymentTossDtoImpl paymentTossDto = paymentTossClient.approvePayment(tossHost + "/confirm",

--- a/src/main/java/flab/payment_system/domain/product/controller/ProductController.java
+++ b/src/main/java/flab/payment_system/domain/product/controller/ProductController.java
@@ -21,7 +21,7 @@ public class ProductController {
 	private final ProductService productService;
 
 	@GetMapping("/{productId}")
-	public ResponseEntity<ProductDto> getProductDetail(@PathVariable int productId) {
+	public ResponseEntity<ProductDto> getProductDetail(@PathVariable Long productId) {
 		ProductDto productDto = productService.getProductDetail(productId);
 
 		return ResponseEntity.ok().body(productDto);

--- a/src/main/java/flab/payment_system/domain/product/dto/ProductDto.java
+++ b/src/main/java/flab/payment_system/domain/product/dto/ProductDto.java
@@ -4,11 +4,11 @@ import jakarta.validation.constraints.Min;
 
 public record ProductDto(
 	@Min(value = 1, message = "invalid_product_id")
-	long productId,
+	Long productId,
 	String name,
 	@Min(value = 1, message = "invalid_price")
-	long price,
+	Integer price,
 	@Min(value = 1, message = "invalid_stock")
-	long stock) {
+	Integer stock) {
 
 }

--- a/src/main/java/flab/payment_system/domain/product/service/ProductService.java
+++ b/src/main/java/flab/payment_system/domain/product/service/ProductService.java
@@ -16,14 +16,14 @@ public class ProductService {
 	private final ProductRepository productRepository;
 
 
-	public ProductDto getProductDetail(long productId) {
+	public ProductDto getProductDetail(Long productId) {
 		Product product = productRepository.findById(productId).orElseThrow(
 			ProductNotExistBadRequestException::new);
 		return new ProductDto(product.getProductId(), product.getName(), product.getPrice(),
 			product.getStock());
 	}
 
-	public void checkRemainStock(long productId) {
+	public void checkRemainStock(Long productId) {
 		Product product = productRepository.findById(productId).orElseThrow(
 			ProductNotExistBadRequestException::new);
 		if (product.getStock() == 0) {

--- a/src/main/java/flab/payment_system/domain/user/entity/UserVerification.java
+++ b/src/main/java/flab/payment_system/domain/user/entity/UserVerification.java
@@ -22,7 +22,7 @@ public class UserVerification {
 	private boolean isVerified;
 
 	@Builder
-	public UserVerification(Long verificationId, Long userId, String email,
+	public UserVerification(Long verificationId, String email,
 		Integer verificationNumber,
 		boolean isVerified) {
 		this.verificationId = verificationId;

--- a/src/main/java/flab/payment_system/domain/user/service/UserService.java
+++ b/src/main/java/flab/payment_system/domain/user/service/UserService.java
@@ -166,7 +166,7 @@ public class UserService {
 		sessionAdapter.invalidate(session);
 	}
 
-	public long getUserId(HttpSession session) {
+	public Long getUserId(HttpSession session) {
 		return sessionAdapter.getUserId(session).orElseThrow(UserNotSignInedConflictException::new);
 	}
 }

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,51 @@
+spring:
+  profiles:
+    active: test
+  data:
+    redis:
+      port: ${REDIS_PORT}
+      host: ${REDIS_HOST}
+      password: ${REDIS_PASSWORD}
+
+  mvc:
+    dispatch-options-request: true
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${DB_TEST_URL}/${DB_TEST_DATABASE}?useUnicode=true&characterEncoding=utf8&serverTimezone=UTC&useLegacyDatetimeCode=false
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: update
+  mail:
+    host: ${SMTP_HOST}
+    port: 465
+    username: ${SMTP_ID}
+    password: ${SMTP_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          ssl:
+            enable: true
+            trust: ${SMTP_HOST}
+server:
+  shutdown: graceful
+
+logging:
+  level:
+    root: info
+
+timezone: ${TIMEZONE}
+smtp-id: ${SMTP_ID}
+
+kakao-cid: TC0ONETIME
+kakao-host: https://kapi.kakao.com/v1/payment
+kakao-adminkey: ${KAKAO_ADMIN_KEY}
+
+toss-host: https://api.tosspayments.com/v1/payments
+toss-client-key: ${TOSS_CLIENT_KEY}
+toss-secret-key: ${TOSS_SECRET_KEY}
+
+

--- a/src/test/java/flab/payment_system/PaymentSystemApplicationTests.java
+++ b/src/test/java/flab/payment_system/PaymentSystemApplicationTests.java
@@ -3,7 +3,7 @@ package flab.payment_system;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(properties = {"spring.config.location=classpath:application-test.yml"})
 class PaymentSystemApplicationTests {
 
 	@Test

--- a/src/test/java/flab/payment_system/order/service/OrderProductServiceIntegrationTest.java
+++ b/src/test/java/flab/payment_system/order/service/OrderProductServiceIntegrationTest.java
@@ -33,10 +33,10 @@ public class OrderProductServiceIntegrationTest {
 	@Test
 	public void orderProductSuccess() {
 		// given
-		long userId = 1;
-		OrderProductDto orderProductDto = new OrderProductDto("초코파이", 1, 2, 5000, 5000, 0);
+		Long userId = 1L;
+		OrderProductDto orderProductDto = new OrderProductDto("초코파이", 1L, 2, 5000, 5000, 0);
 		// when
-		long orderId = orderService.orderProduct(orderProductDto, userId);
+		Long orderId = orderService.orderProduct(orderProductDto, userId);
 		OrderProduct orderProduct = orderRepository.findById(orderId).orElse(null);
 		// then
 		Assertions.assertEquals(orderId, orderProduct.getOrderId());

--- a/src/test/java/flab/payment_system/order/service/OrderProductServiceIntegrationTest.java
+++ b/src/test/java/flab/payment_system/order/service/OrderProductServiceIntegrationTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(properties = {"spring.config.location=classpath:application-test.yml"})
 public class OrderProductServiceIntegrationTest {
 
 	@Autowired

--- a/src/test/java/flab/payment_system/payment/service/PaymentServiceIntegrationTest.java
+++ b/src/test/java/flab/payment_system/payment/service/PaymentServiceIntegrationTest.java
@@ -51,12 +51,12 @@ public class PaymentServiceIntegrationTest {
 		@Test
 		public void createKakaoPaymentSuccess() {
 			// given
-			long userId = 1;
+			Long userId = 1L;
 			PaymentPgCompany pgCompany = PaymentPgCompany.KAKAO;
-			OrderProductDto orderProductDto = new OrderProductDto("초코파이", 1, 2, 5000, 5000, 0);
+			OrderProductDto orderProductDto = new OrderProductDto("초코파이", 1L, 2, 5000, 5000, 0);
 
 			// when
-			long orderId = orderService.orderProduct(orderProductDto, userId);
+			Long orderId = orderService.orderProduct(orderProductDto, userId);
 			paymentService.setStrategy(pgCompany);
 			PaymentKakaoReadyDtoImpl paymentReadyDto = (PaymentKakaoReadyDtoImpl) paymentService.createPayment(
 				orderProductDto, requestUrl,
@@ -72,12 +72,12 @@ public class PaymentServiceIntegrationTest {
 		@Test
 		public void createTossPaymentSuccess() {
 			// given
-			long userId = 1;
+			Long userId = 1L;
 			PaymentPgCompany pgCompany = PaymentPgCompany.TOSS;
-			OrderProductDto orderProductDto = new OrderProductDto("초코파이", 1, 2, 5000, 5000, 0);
+			OrderProductDto orderProductDto = new OrderProductDto("초코파이", 1L, 2, 5000, 5000, 0);
 
 			// when
-			long orderId = orderService.orderProduct(orderProductDto, userId);
+			Long orderId = orderService.orderProduct(orderProductDto, userId);
 			paymentService.setStrategy(pgCompany);
 			PaymentTossDtoImpl paymentReadyDto = (PaymentTossDtoImpl) paymentService.createPayment(
 				orderProductDto, requestUrl,

--- a/src/test/java/flab/payment_system/payment/service/PaymentServiceIntegrationTest.java
+++ b/src/test/java/flab/payment_system/payment/service/PaymentServiceIntegrationTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(properties = {"spring.config.location=classpath:application-test.yml"})
 public class PaymentServiceIntegrationTest {
 
 	@Autowired

--- a/src/test/java/flab/payment_system/user/service/UserServiceIntegrationTest.java
+++ b/src/test/java/flab/payment_system/user/service/UserServiceIntegrationTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(properties = {"spring.config.location=classpath:application-test.yml"})
 public class UserServiceIntegrationTest {
 
 	@Autowired


### PR DESCRIPTION
1. 원시타입과 참조 데이터 타입 섞어써 박싱, 언박싱을 반복하며 성능이 느려질 수 있고 가독성이 떨어지는 문제 가능성
-> 위를 보완하기 위해, 참조 데이터 타입으로 통일했습니다.
2. 테스트 환경을 따로 사용하기 위해 application-test.yml 을 추가해줬습니다.
3. 외부 API를 사용하기 위해 보내줘야하는 body값이 미세하게 변경돼 변경사항을 반영했습니다.
4. restTemplate의 connection pool 을 생성해줬습니다.