### PR TITLE
전략패턴 로직 점검

### DIFF
--- a/src/main/java/flab/payment_system/adapter/OrderAdapter.java
+++ b/src/main/java/flab/payment_system/adapter/OrderAdapter.java
@@ -3,7 +3,6 @@ package flab.payment_system.adapter;
 import flab.payment_system.domain.order.dto.OrderCancelDto;
 import flab.payment_system.domain.payment.enums.PaymentPgCompany;
 import flab.payment_system.domain.payment.response.PaymentCancelDto;
-import flab.payment_system.domain.payment.response.PaymentOrderDetailDto;
 import flab.payment_system.domain.product.entity.Product;
 import flab.payment_system.domain.user.entity.User;
 import jakarta.servlet.http.HttpSession;

--- a/src/main/java/flab/payment_system/adapter/OrderAdapter.java
+++ b/src/main/java/flab/payment_system/adapter/OrderAdapter.java
@@ -12,12 +12,7 @@ public interface OrderAdapter {
 
 	Long getUserId(HttpSession session);
 
-
-	void setStrategy(PaymentPgCompany pgCompany);
-
-	PaymentCancelDto cancelPayment(OrderCancelDto orderCancelDto);
-
-	PaymentOrderDetailDto getOrderDetail(String paymentKey);
+	PaymentCancelDto cancelPayment(OrderCancelDto orderCancelDto, PaymentPgCompany pgCompany);
 
 	Product getProductByProductId(Long productId);
 

--- a/src/main/java/flab/payment_system/adapter/OrderAdapterImpl.java
+++ b/src/main/java/flab/payment_system/adapter/OrderAdapterImpl.java
@@ -31,18 +31,8 @@ public class OrderAdapterImpl implements OrderAdapter {
 	}
 
 	@Override
-	public void setStrategy(PaymentPgCompany pgCompany) {
-		paymentService.setStrategy(pgCompany);
-	}
-
-	@Override
-	public PaymentCancelDto cancelPayment(OrderCancelDto orderCancelDto) {
-		return paymentService.cancelPayment(orderCancelDto);
-	}
-
-	@Override
-	public PaymentOrderDetailDto getOrderDetail(String paymentKey) {
-		return paymentService.getOrderDetail(paymentKey);
+	public PaymentCancelDto cancelPayment(OrderCancelDto orderCancelDto, PaymentPgCompany pgCompany) {
+		return paymentService.cancelPayment(orderCancelDto, pgCompany);
 	}
 
 	@Override

--- a/src/main/java/flab/payment_system/adapter/OrderAdapterImpl.java
+++ b/src/main/java/flab/payment_system/adapter/OrderAdapterImpl.java
@@ -3,7 +3,6 @@ package flab.payment_system.adapter;
 import flab.payment_system.domain.order.dto.OrderCancelDto;
 import flab.payment_system.domain.payment.enums.PaymentPgCompany;
 import flab.payment_system.domain.payment.response.PaymentCancelDto;
-import flab.payment_system.domain.payment.response.PaymentOrderDetailDto;
 import flab.payment_system.domain.payment.service.PaymentService;
 import flab.payment_system.domain.product.entity.Product;
 import flab.payment_system.domain.product.service.ProductService;
@@ -11,6 +10,7 @@ import flab.payment_system.domain.user.entity.User;
 import flab.payment_system.domain.user.service.UserService;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Component;
 
 @Component

--- a/src/main/java/flab/payment_system/adapter/PaymentAdapterImpl.java
+++ b/src/main/java/flab/payment_system/adapter/PaymentAdapterImpl.java
@@ -17,6 +17,14 @@ public class PaymentAdapterImpl implements PaymentAdapter {
 	private final OrderService orderService;
 	private final RedissonLockService redissonLockService;
 
+	@Autowired
+	public PaymentAdapterImpl(UserService userService, @Lazy OrderService orderService,
+		@Lazy RedissonLockService redissonLockService) {
+		this.userService = userService;
+		this.orderService = orderService;
+		this.redissonLockService = redissonLockService;
+	}
+
 	@Override
 	public Long getUserId(HttpSession session) {
 		return userService.getUserId(session);

--- a/src/main/java/flab/payment_system/adapter/PaymentAdapterImpl.java
+++ b/src/main/java/flab/payment_system/adapter/PaymentAdapterImpl.java
@@ -5,11 +5,12 @@ import flab.payment_system.domain.order.service.OrderService;
 import flab.payment_system.domain.redisson.service.RedissonLockService;
 import flab.payment_system.domain.user.service.UserService;
 import jakarta.servlet.http.HttpSession;
-import lombok.RequiredArgsConstructor;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
 @Component
-@RequiredArgsConstructor
 public class PaymentAdapterImpl implements PaymentAdapter {
 
 	private final UserService userService;
@@ -25,7 +26,6 @@ public class PaymentAdapterImpl implements PaymentAdapter {
 	public OrderProduct getOrderProductByOrderId(Long orderId) {
 		return orderService.getOrderProductByOrderId(orderId);
 	}
-
 
 	@Override
 	public void increaseStock(Long productId, Integer quantity) {

--- a/src/main/java/flab/payment_system/config/PaymentStrategyConfig.java
+++ b/src/main/java/flab/payment_system/config/PaymentStrategyConfig.java
@@ -1,0 +1,38 @@
+package flab.payment_system.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+
+import flab.payment_system.domain.payment.enums.PaymentPgCompany;
+import flab.payment_system.domain.payment.service.PaymentStrategy;
+import flab.payment_system.domain.payment.service.kakao.PaymentStrategyKaKaoService;
+import flab.payment_system.domain.payment.service.toss.PaymentStrategyTossService;
+
+@Configuration
+public class PaymentStrategyConfig {
+
+	private final PaymentStrategyKaKaoService paymentStrategyKaKaoService;
+
+	private final PaymentStrategyTossService paymentStrategyTossService;
+
+	@Autowired
+	public PaymentStrategyConfig(@Lazy PaymentStrategyKaKaoService paymentStrategyKaKaoService,
+		@Lazy PaymentStrategyTossService paymentStrategyTossService) {
+		this.paymentStrategyKaKaoService = paymentStrategyKaKaoService;
+		this.paymentStrategyTossService = paymentStrategyTossService;
+
+	}
+
+	@Bean
+	public Map<PaymentPgCompany, PaymentStrategy> paymentStrategies() {
+		Map<PaymentPgCompany, PaymentStrategy> paymentStrategies = new HashMap<>();
+		paymentStrategies.put(PaymentPgCompany.KAKAO, paymentStrategyKaKaoService);
+		paymentStrategies.put(PaymentPgCompany.TOSS, paymentStrategyTossService);
+		return paymentStrategies;
+	}
+}

--- a/src/main/java/flab/payment_system/domain/order/controller/OrderController.java
+++ b/src/main/java/flab/payment_system/domain/order/controller/OrderController.java
@@ -39,19 +39,9 @@ public class OrderController {
 	public ResponseEntity<PaymentCancelDto> orderCancel(
 		@PathVariable PaymentPgCompany pgCompany,
 		@RequestBody @Valid OrderCancelDto orderCancelDto) {
-		orderAdapter.setStrategy(pgCompany);
-		PaymentCancelDto paymentCancelDto = orderAdapter.cancelPayment(orderCancelDto);
+		PaymentCancelDto paymentCancelDto = orderAdapter.cancelPayment(orderCancelDto, pgCompany);
 
 		return ResponseEntity.ok().body(paymentCancelDto);
-	}
-
-	@GetMapping("/{pgCompany}")
-	public ResponseEntity<PaymentOrderDetailDto> getOrderDetail(
-		@PathVariable PaymentPgCompany pgCompany, @RequestParam String paymentKey) {
-		orderAdapter.setStrategy(pgCompany);
-		PaymentOrderDetailDto paymentOrderDetailDto = orderAdapter.getOrderDetail(paymentKey);
-
-		return ResponseEntity.ok().body(paymentOrderDetailDto);
 	}
 }
 

--- a/src/main/java/flab/payment_system/domain/order/controller/OrderController.java
+++ b/src/main/java/flab/payment_system/domain/order/controller/OrderController.java
@@ -1,6 +1,5 @@
 package flab.payment_system.domain.order.controller;
 
-
 import flab.payment_system.adapter.OrderAdapter;
 import flab.payment_system.domain.order.dto.OrderCancelDto;
 import flab.payment_system.domain.order.dto.OrderDto;
@@ -8,19 +7,16 @@ import flab.payment_system.domain.order.dto.OrderProductDto;
 import flab.payment_system.domain.order.service.OrderService;
 import flab.payment_system.domain.payment.enums.PaymentPgCompany;
 import flab.payment_system.domain.payment.response.PaymentCancelDto;
-import flab.payment_system.domain.payment.response.PaymentOrderDetailDto;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
 
 @RestController
 @RequiredArgsConstructor
@@ -38,7 +34,6 @@ public class OrderController {
 
 		return ResponseEntity.ok().body(orderDto);
 	}
-
 
 	@PostMapping("/{pgCompany}/cancel")
 	public ResponseEntity<PaymentCancelDto> orderCancel(

--- a/src/main/java/flab/payment_system/domain/order/service/OrderService.java
+++ b/src/main/java/flab/payment_system/domain/order/service/OrderService.java
@@ -4,14 +4,13 @@ import flab.payment_system.adapter.OrderAdapter;
 import flab.payment_system.domain.order.dto.OrderDto;
 import flab.payment_system.domain.order.dto.OrderProductDto;
 import flab.payment_system.domain.order.entity.OrderProduct;
-import flab.payment_system.domain.payment.dto.PaymentCreateDto;
 import flab.payment_system.domain.order.exception.OrderNotExistBadRequestException;
 import flab.payment_system.domain.order.repository.OrderRepository;
 
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 
 @RequiredArgsConstructor
 @Service

--- a/src/main/java/flab/payment_system/domain/payment/controller/PaymentController.java
+++ b/src/main/java/flab/payment_system/domain/payment/controller/PaymentController.java
@@ -1,18 +1,26 @@
 package flab.payment_system.domain.payment.controller;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
 import flab.payment_system.adapter.PaymentAdapter;
 import flab.payment_system.common.response.ResponseMessage;
 import flab.payment_system.domain.payment.dto.PaymentCreateDto;
 import flab.payment_system.domain.payment.enums.PaymentPgCompany;
 import flab.payment_system.domain.payment.response.PaymentApprovalDto;
+import flab.payment_system.domain.payment.response.PaymentOrderDetailDto;
 import flab.payment_system.domain.payment.response.PaymentReadyDto;
 import flab.payment_system.domain.payment.service.PaymentService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -38,7 +46,6 @@ public class PaymentController {
 
 		return ResponseEntity.ok().body(paymentReadyDto);
 	}
-
 
 	@GetMapping("/{pgCompany}/approved")
 	public ResponseEntity<PaymentApprovalDto> paymentApproved(

--- a/src/main/java/flab/payment_system/domain/payment/controller/PaymentController.java
+++ b/src/main/java/flab/payment_system/domain/payment/controller/PaymentController.java
@@ -40,7 +40,6 @@ public class PaymentController {
 
 		Long userId = paymentAdapter.getUserId(session);
 
-		paymentService.setStrategy(pgCompany);
 		PaymentReadyDto paymentReadyDto = paymentService.createPayment(paymentCreateDto, requestUrl,
 			userId, pgCompany);
 
@@ -54,19 +53,26 @@ public class PaymentController {
 		@RequestParam("paymentId") Long paymentId, @RequestParam("productId") Long productId
 		, @RequestParam("quantity") Integer quantity,
 		HttpSession session) {
-		paymentService.setStrategy(pgCompany);
 		Long userId = paymentAdapter.getUserId(session);
-		PaymentApprovalDto paymentApprovalDto = paymentService.approvePayment(pgToken, orderId, userId, paymentId, productId, quantity);
+		PaymentApprovalDto paymentApprovalDto = paymentService.approvePayment(pgToken, orderId, userId, paymentId,
+			productId, quantity, pgCompany);
 
 		return ResponseEntity.ok().body(paymentApprovalDto);
 	}
 
 	@GetMapping("/{pgCompany}/fail")
 	public ResponseEntity<ResponseMessage> paymentFail(@PathVariable PaymentPgCompany pgCompany,
-													   @RequestParam("paymentId") Long paymentId) {
-		paymentService.setStrategy(pgCompany);
+		@RequestParam("paymentId") Long paymentId) {
 		paymentService.failPayment(paymentId);
 		return ResponseEntity.ok().body(new ResponseMessage("fail"));
+	}
+
+	@GetMapping("/{pgCompany}")
+	public ResponseEntity<PaymentOrderDetailDto> paymentOrderDetail(
+		@PathVariable PaymentPgCompany pgCompany, @RequestParam String paymentKey) {
+		PaymentOrderDetailDto paymentOrderDetailDto = paymentService.getOrderDetail(paymentKey, pgCompany);
+
+		return ResponseEntity.ok().body(paymentOrderDetailDto);
 	}
 }
 

--- a/src/main/java/flab/payment_system/domain/payment/enums/PaymentPgCompany.java
+++ b/src/main/java/flab/payment_system/domain/payment/enums/PaymentPgCompany.java
@@ -3,7 +3,6 @@ package flab.payment_system.domain.payment.enums;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-
 @RequiredArgsConstructor
 @Getter
 public enum PaymentPgCompany {

--- a/src/main/java/flab/payment_system/domain/payment/repository/PaymentCustomRepositoryImpl.java
+++ b/src/main/java/flab/payment_system/domain/payment/repository/PaymentCustomRepositoryImpl.java
@@ -1,8 +1,10 @@
 package flab.payment_system.domain.payment.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import flab.payment_system.domain.payment.domain.QPayment;
+
+import flab.payment_system.domain.payment.entity.QPayment;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/flab/payment_system/domain/payment/repository/kakao/KaKaoPaymentCustomRepositoryImpl.java
+++ b/src/main/java/flab/payment_system/domain/payment/repository/kakao/KaKaoPaymentCustomRepositoryImpl.java
@@ -1,8 +1,10 @@
 package flab.payment_system.domain.payment.repository.kakao;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import flab.payment_system.domain.payment.domain.kakao.QKakaoPayment;
+
+import flab.payment_system.domain.payment.entity.kakao.QKakaoPayment;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Repository;
 
 @RequiredArgsConstructor

--- a/src/main/java/flab/payment_system/domain/payment/repository/toss/TossPaymentCustomRepositoryImpl.java
+++ b/src/main/java/flab/payment_system/domain/payment/repository/toss/TossPaymentCustomRepositoryImpl.java
@@ -1,7 +1,9 @@
 package flab.payment_system.domain.payment.repository.toss;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Repository;
 
 @RequiredArgsConstructor

--- a/src/main/java/flab/payment_system/domain/payment/service/kakao/PaymentStrategyKaKaoService.java
+++ b/src/main/java/flab/payment_system/domain/payment/service/kakao/PaymentStrategyKaKaoService.java
@@ -13,11 +13,11 @@ import flab.payment_system.domain.payment.response.PaymentReadyDto;
 import flab.payment_system.domain.payment.response.kakao.PaymentKakaoApprovalDtoImpl;
 import flab.payment_system.domain.payment.service.PaymentService;
 import flab.payment_system.domain.payment.service.PaymentStrategy;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.util.MultiValueMap;
-
 
 @Component
 public class PaymentStrategyKaKaoService implements PaymentStrategy {
@@ -41,7 +41,8 @@ public class PaymentStrategyKaKaoService implements PaymentStrategy {
 	}
 
 	@Override
-	public PaymentReadyDto createPayment(PaymentCreateDto paymentCreateDto, Long userId, String requestUrl, Long paymentId) {
+	public PaymentReadyDto createPayment(PaymentCreateDto paymentCreateDto, Long userId, String requestUrl,
+		Long paymentId) {
 
 		HttpEntity<MultiValueMap<String, String>> body = paymentKakaoRequestBodyFactory.getBodyForCreatePayment(
 			paymentCreateDto, userId, requestUrl, paymentId);
@@ -51,7 +52,7 @@ public class PaymentStrategyKaKaoService implements PaymentStrategy {
 
 	@Override
 	public PaymentApprovalDto approvePayment(String pgToken, Long orderId, Long userId,
-											 Long paymentId) {
+		Long paymentId) {
 		HttpEntity<MultiValueMap<String, String>> body = paymentKakaoRequestBodyFactory.getBodyForApprovePayment(
 			pgToken, orderId,
 			userId, paymentId);

--- a/src/main/java/flab/payment_system/domain/payment/service/toss/PaymentStrategyTossService.java
+++ b/src/main/java/flab/payment_system/domain/payment/service/toss/PaymentStrategyTossService.java
@@ -1,6 +1,5 @@
 package flab.payment_system.domain.payment.service.toss;
 
-
 import flab.payment_system.domain.order.dto.OrderCancelDto;
 import flab.payment_system.domain.payment.dto.PaymentCreateDto;
 import flab.payment_system.domain.payment.client.toss.PaymentTossClient;
@@ -21,7 +20,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
-
 
 @Component
 public class PaymentStrategyTossService implements PaymentStrategy {
@@ -44,10 +42,9 @@ public class PaymentStrategyTossService implements PaymentStrategy {
 		this.paymentService = paymentService;
 	}
 
-
 	@Override
 	public PaymentReadyDto createPayment(PaymentCreateDto paymentCreateDto, Long userId,
-										 String requestUrl, Long paymentId) {
+		String requestUrl, Long paymentId) {
 		HttpEntity<Map<String, String>> body = paymentTossRequestBodyFactory.getBodyForCreatePayment(
 			paymentCreateDto, userId, requestUrl, paymentId);
 		return paymentTossClient.createPayment(tossHost, body);
@@ -55,16 +52,20 @@ public class PaymentStrategyTossService implements PaymentStrategy {
 
 	@Override
 	public PaymentApprovalDto approvePayment(String pgToken, Long orderId, Long userId,
-											 Long paymentId) {
+		Long paymentId) {
 		HttpEntity<Map<String, String>> body = paymentTossRequestBodyFactory.getBodyForApprovePayment(
 			orderId, userId, paymentId);
 		PaymentTossDtoImpl paymentTossDto = paymentTossClient.approvePayment(tossHost + "/confirm",
 			body);
 
 		tossPaymentRepository.save(
-			TossPayment.builder().payment(paymentService.getPaymentByPaymentId(paymentId)).country(paymentTossDto.getCountry())
+			TossPayment.builder()
+				.payment(paymentService.getPaymentByPaymentId(paymentId))
+				.country(paymentTossDto.getCountry())
 				.currency(
-					paymentTossDto.getCurrency()).type(paymentTossDto.getType()).build());
+					paymentTossDto.getCurrency())
+				.type(paymentTossDto.getType())
+				.build());
 
 		return paymentTossDto;
 	}


### PR DESCRIPTION
1. Application Context 를 통한 DL과 @RequestScope를 이용한 전략패턴 사용 대신 Map<enum, 전략빈> 을 통해 강한 결합과 메모리 비효율성 해결 
2. 로직 변경 시 생긴 순환참조 수정자 주입을 통해 해결